### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [Critical CodeQL alert1](https://github.com/orgs/ghas-bootcamp-2025-03-18-cloudlabs085/security/campaigns/2) security campaign:
- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/56



- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/55



- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/10
To fix the issue, we need to ensure that the XML parser is always securely configured to prevent XXE attacks. This involves disabling the parsing of external entities and DTDs unconditionally. We will update the `parseXml` method in the `CommentsCache` class to always set the necessary properties on the `XMLInputFactory` to prevent XXE.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
