### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -23,6 +23,7 @@
 package org.owasp.webgoat.lessons.ssrf;
 
 import java.io.IOException;
+import java.util.List;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -45,8 +46,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
     return furBall(url);
   }
 
+  private static final List<String> ALLOWED_URLS = List.of("http://ifconfig.pro");
+
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    if (ALLOWED_URLS.contains(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [Critical CodeQL alert1](https://github.com/orgs/ghas-bootcamp-2025-03-18-cloudlabs085/security/campaigns/2) security campaign:
- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/56
To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of allowed URLs or domains. This can be done by maintaining a whitelist of allowed URLs and checking the user input against this list before proceeding with the request.

  The best way to fix this problem without changing existing functionality is to introduce a whitelist of allowed URLs and validate the user input against this list. If the user-provided URL is not in the whitelist, we should return a failure result.
  


- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/55



- https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/10
To fix the issue, we need to ensure that the XML parser is always securely configured to prevent XXE attacks. This involves disabling the parsing of external entities and DTDs unconditionally. We will update the `parseXml` method in the `CommentsCache` class to always set the necessary properties on the `XMLInputFactory` to prevent XXE.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
