### PR TITLE
Potential fix for code scanning alert no. 56: Server-side request forgery

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -23,6 +23,7 @@
 package org.owasp.webgoat.lessons.ssrf;
 
 import java.io.IOException;
+import java.util.List;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -45,8 +46,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
     return furBall(url);
   }
 
+  private static final List<String> ALLOWED_URLS = List.of("http://ifconfig.pro");
+
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    if (ALLOWED_URLS.contains(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =


### PR DESCRIPTION
Potential fix for [https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/56](https://github.com/ghas-bootcamp-2025-03-18-cloudlabs085/ghas-bootcamp-WebGoat1/security/code-scanning/56)

To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of allowed URLs or domains. This can be done by maintaining a whitelist of allowed URLs and checking the user input against this list before proceeding with the request.

The best way to fix this problem without changing existing functionality is to introduce a whitelist of allowed URLs and validate the user input against this list. If the user-provided URL is not in the whitelist, we should return a failure result.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
